### PR TITLE
update mmark example

### DIFF
--- a/example-mmark/Makefile
+++ b/example-mmark/Makefile
@@ -1,12 +1,10 @@
 #
-# Makefile to build Internet Drafts from markdown using mmarc and
+# Makefile to build Internet Drafts from markdown using mmark and
 # relying on the docker image "paulej/rfctools".
 #
 
 SRC  := $(wildcard draft-*.md)
 TXT  := $(patsubst %.md,%.txt,$(SRC))
-UID  := `id -u`
-GID  := `id -g`
 CWD  := `pwd`
 
 # Ensure the xml2rfc cache directory exists locally
@@ -17,5 +15,14 @@ all: $(TXT) $(HTML)
 clean:
 	rm -f draft*.txt draft-*.xml
 
-%.txt: %.md
-	docker run --rm --user=$(UID):$(GID) -v $(CWD):/rfc -v $(HOME)/.cache/xml2rfc:/var/cache/xml2rfc paulej/rfctools md2rfc $^
+%.txt: %.xml
+	xml2rfc --text -o $@ $<
+
+%.html: %.xml
+	xml2rfc --html -o $@ $<
+
+%.xml: %.md
+	mmark -2 < $< > $@
+
+clean:
+	rm -f draft-*.txt draft-*.html draft-*.xml

--- a/example-mmark/draft-example-mmark.md
+++ b/example-mmark/draft-example-mmark.md
@@ -25,34 +25,79 @@ organization = "TODO Organization"
 
 .# Abstract
 
-TODO Abstract
+This is an example of using markdown in the creation of an Internet Draft. The
+specific flavor of markdown being used is mmark version 2, created by
+Miek Gieben and available at [https://github.com/mmarkdown/mmark/](https://github.com/mmarkdown/mmark/).
 
 {mainmatter}
 
 # Introduction
 
-TODO Introduction
-
+More information can be found in [@!I-D.nottingham-for-the-users]. (An
+example of an informative reference in the middle of text. Note that
+referencing an Internet Draft involves replacing "draft-" in the name with
+"I-D.".)
 
 # Conventions and Definitions
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
-document are to be interpreted as described in BCP 14 {{RFC2119}} {{!RFC8174}}
+document are to be interpreted as described in BCP 14 [@!RFC2119] [@RFC8174]
 when, and only when, they appear in all capitals, as shown here.
 
+The reader may wish to note that one of the two RFC references in the
+preceding paragraph was normative; the other was informative. These will
+be correctly identified as such in the References section below.
+
+# Background
+
+This is some background text
+
+# Use Cases {#usecases}
+
+This section will include some use cases for our new protocol. The use
+cases conform to the guidelines found in [@!RFC7268]. (Demonstrating a
+normative reference inline.)
+
+Note that the section heading also includes an anchor name that can be
+referenced in a cross reference later in the document, as is done in
+(#security-considerations) of this document. (Demonstrating using a
+reference to a heading without writing an actual anchor, but rather using
+the heading name in lowercase and with dashes.)
+
+## First use case
+
+Some text about the first use case. (And an example of using a second level
+heading.)
+
+## Second use case
+
+This example includes a list:
+
+- first item
+- second item
+- third item
+
+And text below the list.
+
+## Third use case
+
+This use case includes some ascii art.  The format for this art is as follows:
+
+~~~ ascii-art
+        0
+       +-+
+       |A|
+       +-+
+~~~
 
 # Security Considerations
 
-TODO Security
-
+As outlined earlier in (#usecases), there could be security issues in
+various use cases.
 
 # IANA Considerations
 
 This document has no IANA actions.
-
-# Acknowledgments
-
-TODO acknowledge.
 
 {backmatter}

--- a/example-mmark/draft-example-mmark.txt
+++ b/example-mmark/draft-example-mmark.txt
@@ -4,16 +4,17 @@
 
 TODO Working Group                                               T. Todo
 Internet-Draft                                         TODO Organization
-Intended status: Informational                             June 12, 2018
-Expires: December 14, 2018
+Expires: January 7, 2020                                    July 6, 2019
 
 
                            TODO - Your title
-                       draft-todo-your-name-here
 
 Abstract
 
-   TODO Abstract
+   This is an example of using markdown in the creation of an Internet
+   Draft.  The specific flavor of markdown being used is mmark version
+   2, created by Miek Gieben and available at
+   https://github.com/mmarkdown/mmark/ .
 
 Status of This Memo
 
@@ -30,11 +31,11 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on December 14, 2018.
+   This Internet-Draft will expire on January 7, 2020.
 
 Copyright Notice
 
-   Copyright (c) 2018 IETF Trust and the persons identified as the
+   Copyright (c) 2019 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -52,44 +53,138 @@ Copyright Notice
 
 
 
-
-Todo                    Expires December 14, 2018               [Page 1]
+Todo                     Expires January 7, 2020                [Page 1]
 
-Internet-Draft             TODO - Abbreviation                 June 2018
+Internet-Draft             TODO - Abbreviation                 July 2019
 
 
 Table of Contents
 
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
    2.  Conventions and Definitions . . . . . . . . . . . . . . . . .   2
-   3.  Security Considerations . . . . . . . . . . . . . . . . . . .   2
-   4.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   2
-   5.  Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .   2
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .   2
+   3.  Background  . . . . . . . . . . . . . . . . . . . . . . . . .   2
+   4.  Use Cases . . . . . . . . . . . . . . . . . . . . . . . . . .   2
+     4.1.  First use case  . . . . . . . . . . . . . . . . . . . . .   3
+     4.2.  Second use case . . . . . . . . . . . . . . . . . . . . .   3
+     4.3.  Third use case  . . . . . . . . . . . . . . . . . . . . .   3
+   5.  Security Considerations . . . . . . . . . . . . . . . . . . .   3
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   3
+   7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   3
+     7.1.  Normative References  . . . . . . . . . . . . . . . . . .   3
+     7.2.  Informative References  . . . . . . . . . . . . . . . . .   4
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .   4
 
 1.  Introduction
 
-   TODO Introduction
+   More information can be found in [I-D.nottingham-for-the-users].  (An
+   example of an informative reference in the middle of text.  Note that
+   referencing an Internet Draft involves replacing "draft-" in the name
+   with "I-D.".)
 
 2.  Conventions and Definitions
 
    The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
    "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
    "OPTIONAL" in this document are to be interpreted as described in BCP
-   14 {{RFC2119}} {{!RFC8174}} when, and only when, they appear in all
+   14 [RFC2119] [RFC8174] when, and only when, they appear in all
    capitals, as shown here.
 
-3.  Security Considerations
+   The reader may wish to note that one of the two RFC references in the
+   preceding paragraph was normative; the other was informative.  These
+   will be correctly identified as such in the References section below.
 
-   TODO Security
+3.  Background
 
-4.  IANA Considerations
+   This is some background text
+
+4.  Use Cases
+
+   This section will include some use cases for our new protocol.  The
+   use cases conform to the guidelines found in [RFC7268].
+   (Demonstrating a normative reference inline.)
+
+   Note that the section heading also includes an anchor name that can
+   be referenced in a cross reference later in the document, as is done
+   in Section 5 of this document.  (Demonstrating using a reference to a
+
+
+
+Todo                     Expires January 7, 2020                [Page 2]
+
+Internet-Draft             TODO - Abbreviation                 July 2019
+
+
+   heading without writing an actual anchor, but rather using the
+   heading name in lowercase and with dashes.)
+
+4.1.  First use case
+
+   Some text about the first use case.  (And an example of using a
+   second level heading.)
+
+4.2.  Second use case
+
+   This example includes a list:
+
+   o  first item
+
+   o  second item
+
+   o  third item
+
+   And text below the list.
+
+4.3.  Third use case
+
+   This use case includes some ascii art.  The format for this art is as
+   follows:
+
+           0
+          +-+
+          |A|
+          +-+
+
+5.  Security Considerations
+
+   As outlined earlier in Section 4, there could be security issues in
+   various use cases.
+
+6.  IANA Considerations
 
    This document has no IANA actions.
 
-5.  Acknowledgments
+7.  References
 
-   TODO acknowledge.
+7.1.  Normative References
+
+   [I-D.nottingham-for-the-users]
+              Nottingham, M., "The Internet is for End Users", draft-
+              nottingham-for-the-users-08 (work in progress), June 2019.
+
+
+
+
+
+Todo                     Expires January 7, 2020                [Page 3]
+
+Internet-Draft             TODO - Abbreviation                 July 2019
+
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997, <https://www.rfc-
+              editor.org/info/rfc2119>.
+
+   [RFC7268]  Aboba, B., Malinen, J., Congdon, P., Salowey, J., and M.
+              Jones, "RADIUS Attributes for IEEE 802 Networks",
+              RFC 7268, DOI 10.17487/RFC7268, July 2014,
+              <https://www.rfc-editor.org/info/rfc7268>.
+
+7.2.  Informative References
+
+   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
+              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
+              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
 
 Author's Address
 
@@ -109,4 +204,21 @@ Author's Address
 
 
 
-Todo                    Expires December 14, 2018               [Page 2]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Todo                     Expires January 7, 2020                [Page 4]

--- a/example-mmark/draft-example-mmark.xml
+++ b/example-mmark/draft-example-mmark.xml
@@ -1,79 +1,105 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- name="GENERATOR" content="github.com/mmarkdown/mmark Mmark Markdown Processor - mmark.nl" -->
 <!DOCTYPE rfc SYSTEM 'rfc2629.dtd' []>
-<rfc ipr="trust200902" category="info" docName="draft-todo-your-name-here">
-<?rfc toc="yes"?>
-<?rfc symrefs="yes"?>
-<?rfc sortrefs="yes"?>
-<?rfc compact="yes"?>
-<?rfc subcompact="no"?>
-<?rfc private=""?>
-<?rfc topblock="yes"?>
-<?rfc comments="no"?>
+<rfc ipr="trust200902" xml:lang="en" consensus="yes">
+<?rfc toc="yes"?><?rfc symrefs="yes"?><?rfc sortrefs="yes"?><?rfc compact="yes"?><?rfc subcompact="no"?><?rfc comments="no"?>
 <front>
-<title abbrev="TODO - Abbreviation">TODO - Your title</title>
+<title abbrev="TODO - Abbreviation">TODO - Your title</title><author initials="T." surname="Todo" fullname="Todo Fullname"><organization>TODO Organization</organization><address><postal><street></street>
+</postal><email>todo@example.com</email>
+</address></author>
+<date/>
+<area>General</area><workgroup>TODO Working Group</workgroup><keyword>Internet-Draft</keyword>
 
-<author initials="T." surname="Todo" fullname="Todo Fullname">
-<organization>TODO Organization</organization>
-<address>
-<postal>
-<street></street>
-<city></city>
-<code></code>
-<country></country>
-<region></region>
-</postal>
-<phone></phone>
-<email>todo@example.com</email>
-<uri></uri>
-</address>
-</author>
-<date year="2018" month="June" day="12"/>
-
-<area>General</area>
-<workgroup>TODO Working Group</workgroup>
-<keyword>Internet-Draft</keyword>
-
-
-<abstract>
-<t>TODO Abstract
-</t>
+<abstract><t>This is an example of using markdown in the creation of an Internet Draft. The
+specific flavor of markdown being used is mmark version 2, created by
+Miek Gieben and available at <eref target="https://github.com/mmarkdown/mmark/">https://github.com/mmarkdown/mmark/</eref>.</t>
 </abstract>
-
 
 </front>
 
 <middle>
 
 <section anchor="introduction" title="Introduction">
-<t>TODO Introduction
-</t>
+<t>More information can be found in <xref target="I-D.nottingham-for-the-users"></xref>. (An
+example of an informative reference in the middle of text. Note that
+referencing an Internet Draft involves replacing &quot;draft-&quot; in the name with
+&quot;I-D.&quot;.)</t>
 </section>
 
 <section anchor="conventions-and-definitions" title="Conventions and Definitions">
 <t>The key words &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;,
 &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this
-document are to be interpreted as described in BCP 14 {{RFC2119}} {{!RFC8174}}
-when, and only when, they appear in all capitals, as shown here.
+document are to be interpreted as described in BCP 14 <xref target="RFC2119"></xref> <xref target="RFC8174"></xref>
+when, and only when, they appear in all capitals, as shown here.</t>
+<t>The reader may wish to note that one of the two RFC references in the
+preceding paragraph was normative; the other was informative. These will
+be correctly identified as such in the References section below.</t>
+</section>
+
+<section anchor="background" title="Background">
+<t>This is some background text</t>
+</section>
+
+<section anchor="usecases" title="Use Cases">
+<t>This section will include some use cases for our new protocol. The use
+cases conform to the guidelines found in <xref target="RFC7268"></xref>. (Demonstrating a
+normative reference inline.)</t>
+<t>Note that the section heading also includes an anchor name that can be
+referenced in a cross reference later in the document, as is done in
+<xref target="security-considerations"></xref> of this document. (Demonstrating using a
+reference to a heading without writing an actual anchor, but rather using
+the heading name in lowercase and with dashes.)</t>
+
+<section anchor="first-use-case" title="First use case">
+<t>Some text about the first use case. (And an example of using a second level
+heading.)</t>
+</section>
+
+<section anchor="second-use-case" title="Second use case">
+<t>This example includes a list:</t>
+<t>
+<list style="symbols">
+<t>first item</t>
+<t>second item</t>
+<t>third item</t>
+</list>
 </t>
+<t>And text below the list.</t>
+</section>
+
+<section anchor="third-use-case" title="Third use case">
+<t>This use case includes some ascii art.  The format for this art is as follows:</t>
+
+<figure><artwork type="ascii-art">        0
+       +-+
+       |A|
+       +-+
+</artwork></figure>
+
+</section>
 </section>
 
 <section anchor="security-considerations" title="Security Considerations">
-<t>TODO Security
-</t>
+<t>As outlined earlier in <xref target="usecases"></xref>, there could be security issues in
+various use cases.</t>
 </section>
 
 <section anchor="iana-considerations" title="IANA Considerations">
-<t>This document has no IANA actions.
-</t>
-</section>
-
-<section anchor="acknowledgments" title="Acknowledgments">
-<t>TODO acknowledge.
-</t>
+<t>This document has no IANA actions.</t>
 </section>
 
 </middle>
+
 <back>
+<references title="Normative References">
+<?rfc include="https://xml2rfc.ietf.org/public/rfc/bibxml-ids/reference.I-D.nottingham-for-the-users.xml"?>
+<?rfc include="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml"?>
+<?rfc include="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.7268.xml"?>
+</references>
+<references title="Informative References">
+<?rfc include="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.8174.xml"?>
+</references>
 
 </back>
+
 </rfc>


### PR DESCRIPTION
- add more detail, mostly taken from the kramdown example
- demonstrate references to an I-D as well as to RFCs
- demonstrate ascii art

current syntax is based on mmark version 2.0.16.